### PR TITLE
Add middleware to remove Strict-Transport-Security

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,9 +1,15 @@
 require "active_support/core_ext/integer/time"
+require "strict_transport_security_remover"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   config.force_ssl = true
+
+  config.middleware.insert_before(
+    ActionDispatch::SSL,
+    StrictTransportSecurityRemover
+  )
 
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development

--- a/lib/strict_transport_security_remover.rb
+++ b/lib/strict_transport_security_remover.rb
@@ -1,0 +1,11 @@
+class StrictTransportSecurityRemover
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    @app.call(env).tap do |_, headers, _|
+      headers.delete "Strict-Transport-Security"
+    end
+  end
+end


### PR DESCRIPTION
This is an example pull request to explain the workaround I mentioned in the following pull request:

- https://github.com/rails/rails/issues/48609

By including this workaround, it is possible to keep `config.force_ssl = true` and not add `Strict-Transport-Security` on the Rails application side like this:

```
$ curl --head --header "X-Forwarded-Proto: https" http://localhost:80 
HTTP/1.1 200 OK
Server: nginx/1.25.1
Date: Fri, 30 Jun 2023 08:25:15 GMT
Content-Type: text/html; charset=utf-8
Connection: keep-alive
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 0
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Permitted-Cross-Domain-Policies: none
Referrer-Policy: strict-origin-when-cross-origin
Vary: Accept
ETag: W/"bba8b0d63cfb920be0370770c97ac0c1"
Cache-Control: max-age=0, private, must-revalidate
Content-Security-Policy: script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'
X-Request-Id: 79ff1e54-d8dc-4eff-9e47-2565ea849bb6
X-Runtime: 0.003806
Server-Timing: start_processing.action_controller;dur=0.08, render_template.action_view;dur=0.54, process_action.action_controller;dur=1.68
Strict-Transport-Security: max-age=31536000;
```

However, it is an undesirable situation for Rails users to have to go to the trouble of putting in such workarounds on their end.